### PR TITLE
HTTP CONNECT gun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go: 
   - 1.7.3
+  - 1.8
   - tip
 
 go_import_path: github.com/yandex/pandora

--- a/ammo/http.go
+++ b/ammo/http.go
@@ -16,8 +16,9 @@ import (
 // HTTP ammo interface for http based guns.
 // http ammo providers should produce ammo that implements HTTP.
 // http guns should use convert ammo to HTTP, not to specific implementation.
+// Returned request have
 type HTTP interface {
-	// TODO (skipor) instead of sample use some more usable interface.
+	// TODO(skipor): instead of sample use some more usable interface.
 	Request() (*http.Request, *aggregate.Sample)
 }
 

--- a/ammo/http.go
+++ b/ammo/http.go
@@ -23,9 +23,14 @@ type HTTP interface {
 }
 
 type SimpleHTTP struct {
-	// OPTIMIZE: reuse *http.Request
+	// OPTIMIZE(skipor): reuse *http.Request.
+	// Need to research is it possible. http.Transport can hold reference to http.Request.
 	req *http.Request
 	tag string
+}
+
+func NewSimpleHTTP(req *http.Request, tag string) *SimpleHTTP {
+	return &SimpleHTTP{req, tag}
 }
 
 func (a *SimpleHTTP) Request() (*http.Request, *aggregate.Sample) {

--- a/ammo/jsonline/data.go
+++ b/ammo/jsonline/data.go
@@ -4,9 +4,13 @@ package jsonline
 
 // ffjson: noencoder
 type data struct {
-	Host    string            `json:"host"`
-	Method  string            `json:"method"`
-	Uri     string            `json:"uri"`
+	// Host defines Host header to send.
+	// Request endpoint is defied by gun config.
+	Host   string `json:"host"`
+	Method string `json:"method"`
+	Uri    string `json:"uri"`
+	// Headers defines headers to send.
+	// NOTE: Host header will be silently ignored.
 	Headers map[string]string `json:"headers"`
 	Tag     string            `json:"tag"`
 }

--- a/ammo/jsonline/jsonline_suite_test.go
+++ b/ammo/jsonline/jsonline_suite_test.go
@@ -28,13 +28,13 @@ var testData = []data{
 		Host:    "example.com",
 		Method:  "GET",
 		Uri:     "/00",
-		Headers: map[string]string{"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "example.org", "User-Agent": "Pandora/0.0.1"},
+		Headers: map[string]string{"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"},
 	},
 	{
 		Host:    "ya.ru",
 		Method:  "HEAD",
 		Uri:     "/01",
-		Headers: map[string]string{"Accept": "*/*", "Accept-Encoding": "gzip, brotli", "Host": "ya.ru", "User-Agent": "YaBro/0.1"},
+		Headers: map[string]string{"Accept": "*/*", "Accept-Encoding": "gzip, brotli", "User-Agent": "YaBro/0.1"},
 		Tag:     "head",
 	},
 }

--- a/ammo/uri/decoder.go
+++ b/ammo/uri/decoder.go
@@ -58,7 +58,13 @@ func (d *decoder) decodeURI(line []byte) error {
 		return stackerr.Newf("uri decode error: ", err)
 	}
 	for k, v := range d.header {
-		req.Header[k] = v
+		// http.Request.Write sends Host header based on Host or URL.Host.
+		if k == "Host" {
+			req.URL.Host = v[0]
+			req.Host = v[0]
+		} else {
+			req.Header[k] = v
+		}
 	}
 	sh := d.ammoPool.Get().(*ammo.SimpleHTTP)
 	sh.Reset(req, "REQUEST")

--- a/ammo/uri/decoder_test.go
+++ b/ammo/uri/decoder_test.go
@@ -53,6 +53,8 @@ var _ = Describe("Decoder", func() {
 		for k, v := range header {
 			decoder.header[k] = v
 		}
+		const host = "example.com"
+		decoder.header.Set("Host", host)
 		line := "/some/path"
 		Decode(line)
 		var am ammo.Ammo
@@ -62,10 +64,12 @@ var _ = Describe("Decoder", func() {
 		req, sample := sh.Request()
 		Expect(*req.URL).To(MatchFields(IgnoreExtras, Fields{
 			"Path":   Equal(line),
-			"Host":   BeEmpty(),
+			"Host":   Equal(host),
 			"Scheme": BeEmpty(),
 		}))
+		Expect(req.Host).To(Equal(host))
 		Expect(req.Header).To(Equal(header))
+		header.Set("Host", host)
 		Expect(decoder.header).To(Equal(header))
 		Expect(decoder.ammoNum).To(Equal(1))
 		Expect(sample.Tags()).To(Equal("REQUEST"))

--- a/ammo/uri/provider_test.go
+++ b/ammo/uri/provider_test.go
@@ -16,26 +16,29 @@ const testFile = "./ammo.uri"
 const testFileData = `/0
 [A:b]
 /1
+[Host : example.com]
 [ C : d ]
 /2
 [A:]
+[Host : other.net]
 /3`
 
 var testData = []ammoData{
-	{"/0", http.Header{}},
-	{"/1", http.Header{"A": []string{"b"}}},
-	{"/2", http.Header{
+	{"", "/0", http.Header{}},
+	{"", "/1", http.Header{"A": []string{"b"}}},
+	{"example.com", "/2", http.Header{
 		"A": []string{"b"},
 		"C": []string{"d"},
 	}},
-	{"/3", http.Header{
+	{"other.net", "/3", http.Header{
 		"A": []string{""},
 		"C": []string{"d"},
 	}},
 }
 
 type ammoData struct {
-	uri    string
+	host   string
+	path   string
 	header http.Header
 }
 
@@ -121,17 +124,18 @@ var _ = Describe("provider decode", func() {
 			expectedData := testData[i%len(testData)]
 			ha := ammos[i].(ammo.HTTP)
 			req, ss := ha.Request()
+			By(fmt.Sprintf("%v", i))
 			Expect(*req).To(MatchFields(IgnoreExtras, Fields{
 				"Method":     Equal("GET"),
 				"Proto":      Equal("HTTP/1.1"),
 				"ProtoMajor": Equal(1),
 				"ProtoMinor": Equal(1),
 				"Body":       BeNil(),
-				"Host":       BeEmpty(),
+				"Host":       Equal(expectedData.host),
 				"URL": PointTo(MatchFields(IgnoreExtras, Fields{
 					"Scheme": BeEmpty(),
-					"Host":   BeEmpty(),
-					"Path":   Equal(expectedData.uri),
+					"Host":   Equal(expectedData.host),
+					"Path":   Equal(expectedData.path),
 				})),
 				"Header": Equal(expectedData.header),
 			}))

--- a/cli/config/connect.yaml
+++ b/cli/config/connect.yaml
@@ -1,8 +1,9 @@
 pools:
-  - name: HTTP pool
-    gun:
-      type: http
+  - gun:
+      type: connect
       target: localhost:3000
+      ssl: true
+      connect-ssl: false
     ammo:
       type: jsonline
       file: ./example/data/ammo.jsonline

--- a/gun/gun.go
+++ b/gun/gun.go
@@ -9,5 +9,11 @@ import (
 
 type Gun interface {
 	Shoot(context.Context, ammo.Ammo) error
-	BindResultsTo(chan<- *aggregate.Sample)
+	BindResultsTo(Results)
+}
+
+type Results chan<- *aggregate.Sample
+
+func NewResults(buf int) chan *aggregate.Sample {
+	return make(chan *aggregate.Sample, buf)
 }

--- a/gun/log.go
+++ b/gun/log.go
@@ -9,10 +9,10 @@ import (
 )
 
 type logGun struct {
-	results chan<- *aggregate.Sample
+	results Results
 }
 
-func (l *logGun) BindResultsTo(results chan<- *aggregate.Sample) {
+func (l *logGun) BindResultsTo(results Results) {
 	l.results = results
 }
 

--- a/gun/phttp/base.go
+++ b/gun/phttp/base.go
@@ -14,21 +14,20 @@ import (
 
 	"github.com/facebookgo/stackerr"
 
-	"github.com/yandex/pandora/aggregate"
 	"github.com/yandex/pandora/ammo"
 	"github.com/yandex/pandora/gun"
 )
 
 // TODO: inject logger
 type Base struct {
-	Do      func(r *http.Request) (*http.Response, error) // Required.
-	Connect func(ctx context.Context) error               // Optional hook.
-	Results chan<- *aggregate.Sample                      // Lazy set via BindResultTo.
+	Do          func(r *http.Request) (*http.Response, error) // Required.
+	Connect     func(ctx context.Context) error               // Optional hook.
+	gun.Results                                               // Lazy set via BindResultTo.
 }
 
 var _ gun.Gun = (*Base)(nil)
 
-func (b *Base) BindResultsTo(results chan<- *aggregate.Sample) {
+func (b *Base) BindResultsTo(results gun.Results) {
 	if b.Results != nil {
 		log.Panic("already binded")
 	}

--- a/gun/phttp/base_test.go
+++ b/gun/phttp/base_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/yandex/pandora/aggregate"
 	"github.com/yandex/pandora/ammo/mocks"
+	"github.com/yandex/pandora/gun"
 )
 
 var _ = Describe("Base", func() {
@@ -34,11 +35,11 @@ var _ = Describe("Base", func() {
 			}).To(Panic())
 		})
 		It("second time panics", func() {
-			res := make(chan<- *aggregate.Sample)
+			res := make(gun.Results)
 			base.BindResultsTo(res)
 			Expect(base.Results).To(Equal(res))
 			Expect(func() {
-				base.BindResultsTo(make(chan<- *aggregate.Sample))
+				base.BindResultsTo(make(gun.Results))
 			}).To(Panic())
 		})
 	})

--- a/gun/phttp/client.go
+++ b/gun/phttp/client.go
@@ -6,6 +6,7 @@
 package phttp
 
 import (
+	"context"
 	"log"
 	"net"
 	"net/http"
@@ -49,7 +50,17 @@ func NewDefaultDialerConfig() DialerConfig {
 	}
 }
 
-func NewDialer(conf DialerConfig) *net.Dialer {
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+type DialerFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+func (f DialerFunc) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return f(ctx, network, address)
+}
+
+func NewDialer(conf DialerConfig) Dialer {
 	d := &net.Dialer{}
 	err := config.Map(d, conf)
 	if err != nil {

--- a/gun/phttp/connect.go
+++ b/gun/phttp/connect.go
@@ -1,0 +1,134 @@
+package phttp
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/facebookgo/stackerr"
+	"github.com/yandex/pandora/gun"
+)
+
+type ConnectGunConfig struct {
+	Target     string       `validate:"endpoint,required"`
+	ConnectSSL bool         `config:"connect-ssl"` // Defines if tunnel encrypted.
+	SSL        bool         // As in HTTP gun, defines scheme for http requests.
+	Client     ClientConfig `config:",squash"`
+}
+
+func NewConnectGun(conf ConnectGunConfig) *ConnectGun {
+	scheme := "http"
+	if conf.SSL {
+		scheme = "https"
+	}
+	var g ConnectGun
+	g = ConnectGun{
+		Base:   Base{Do: g.Do},
+		scheme: scheme,
+		client: newConnectClient(conf),
+	}
+	return &g
+}
+
+type ConnectGun struct {
+	Base
+	scheme string
+	client Client
+}
+
+var _ gun.Gun = (*ConnectGun)(nil)
+
+func (g *ConnectGun) Do(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = g.scheme
+	return g.client.Do(req)
+}
+
+func NewDefaultConnectGunConfig() ConnectGunConfig {
+	return ConnectGunConfig{
+		SSL:        false,
+		ConnectSSL: false,
+		Client:     NewDefaultClientConfig(),
+	}
+}
+
+func newConnectClient(conf ConnectGunConfig) Client {
+	transport := NewTransport(conf.Client.Transport)
+	transport.DialContext = newConnectDialer(
+		conf.Target,
+		conf.ConnectSSL,
+		NewDialer(conf.Client.Dialer),
+	).DialContext
+	return &http.Client{Transport: transport}
+}
+
+func newConnectDialer(target string, connectSSL bool, dialer Dialer) Dialer {
+	return DialerFunc(func(ctx context.Context, network, address string) (conn net.Conn, err error) {
+		// TODO(skipor): make httptrace callbacks called correctly.
+		if network != "tcp" {
+			panic("unsupported network " + network)
+		}
+		defer func() {
+			if err != nil && conn != nil {
+				conn.Close()
+				conn = nil
+			}
+		}()
+		// TODO(skipor): make connect sample?
+		conn, err = dialer.DialContext(ctx, "tcp", target)
+		if err != nil {
+			err = stackerr.Wrap(err)
+			return
+		}
+		if connectSSL {
+			conn = tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+		}
+		req := &http.Request{
+			Method:     "CONNECT",
+			URL:        &url.URL{},
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     make(http.Header),
+			Body:       nil,
+			Host:       address,
+		}
+		// NOTE(skipor): any logic for CONNECT request can be easily added via hooks.
+		err = req.Write(conn)
+		if err != nil {
+			err = stackerr.Wrap(err)
+			return
+		}
+		// NOTE(skipor): according to RFC 2817 we can send origin at that moment and not wait
+		// for request. That requires to wrap conn and do following logic at first read.
+		r := bufio.NewReader(conn)
+		res, err := http.ReadResponse(r, req)
+		if err != nil {
+			err = stackerr.Wrap(err)
+			return
+		}
+		// RFC 7230 3.3.3.2: Any 2xx (Successful) response to a CONNECT request implies that
+		// the connection will become a tunnel immediately after the empty
+		// line that concludes the header fields. A client MUST ignore any
+		// Content-Length or Transfer-Encoding header fields received in
+		// such a message.
+		if res.StatusCode != http.StatusOK {
+			dump, dumpErr := httputil.DumpResponse(res, false)
+			err = stackerr.Newf("Unexpected status code. Dumped response:\n%s\n Dump error: %s",
+				dump, dumpErr)
+			return
+		}
+		// No need to close body.
+		if r.Buffered() != 0 {
+			// Already receive something non HTTP from proxy or dialed server.
+			// Anyway it is incorrect situation.
+			peek, _ := r.Peek(r.Buffered())
+			err = stackerr.Newf("Unexpected extra data after connect: %q", peek)
+			return
+		}
+		return
+	})
+}

--- a/gun/phttp/connect_test.go
+++ b/gun/phttp/connect_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 Yandex LLC. All rights reserved.
+// Author: Vladimir Skipor <skipor@yandex-team.ru>
+
+package phttp
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/yandex/pandora/aggregate"
+	"github.com/yandex/pandora/ammo"
+	"github.com/yandex/pandora/gun"
+)
+
+var _ = Describe("connect", func() {
+	tunnelHandler := func(originURL string) http.Handler {
+		u, err := url.Parse(originURL)
+		Expect(err).To(BeNil())
+		originHost := u.Host
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer GinkgoRecover()
+			Expect(originHost).To(Equal(r.RequestURI))
+			toOrigin, err := net.Dial("tcp", originHost)
+			Expect(err).To(BeNil())
+			conn, bufReader, err := w.(http.Hijacker).Hijack()
+			Expect(err).To(BeNil())
+			Expect(bufReader.Reader.Buffered()).To(BeZero(),
+				"Current implementation should not send requested data before got response.")
+			_, err = io.WriteString(conn, "HTTP/1.1 200 Connection established\r\n\r\n")
+			Expect(err).To(BeNil())
+			go func() { io.Copy(toOrigin, conn) }()
+			go func() { io.Copy(conn, toOrigin) }()
+		})
+	}
+
+	testClient := func(tunnelSSL bool) func() {
+		return func() {
+			origin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			}))
+			defer origin.Close()
+
+			var proxy *httptest.Server
+			if tunnelSSL {
+				proxy = httptest.NewTLSServer(tunnelHandler(origin.URL))
+			} else {
+				proxy = httptest.NewServer(tunnelHandler(origin.URL))
+			}
+			defer proxy.Close()
+
+			req, err := http.NewRequest("GET", origin.URL, nil)
+			Expect(err).To(BeNil())
+
+			conf := NewDefaultConnectGunConfig()
+			conf.ConnectSSL = tunnelSSL
+			scheme := "http://"
+			if tunnelSSL {
+				scheme = "https://"
+			}
+			conf.Target = strings.TrimPrefix(proxy.URL, scheme)
+
+			client := newConnectClient(conf)
+
+			res, err := client.Do(req)
+			Expect(err).To(BeNil())
+			Expect(res.StatusCode).To(Equal(http.StatusOK))
+		}
+	}
+
+	It("HTTP client", testClient(false))
+	It("HTTPS client", testClient(true))
+
+	It("gun", func() {
+		origin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+		}))
+		defer origin.Close()
+		proxy := httptest.NewServer(tunnelHandler(origin.URL))
+		defer proxy.Close()
+
+		req, err := http.NewRequest("GET", origin.URL, nil)
+		Expect(err).To(BeNil())
+
+		conf := NewDefaultConnectGunConfig()
+		conf.Target = strings.TrimPrefix(proxy.URL, "http://")
+		connectGun := NewConnectGun(conf)
+
+		results := gun.NewResults(1)
+		connectGun.BindResultsTo(results)
+
+		err = connectGun.Shoot(context.Background(), ammo.NewSimpleHTTP(req, "REQUEST"))
+		Expect(err).To(BeNil())
+
+		var sample *aggregate.Sample
+		Expect(results).To(Receive(&sample))
+
+		Expect(sample.ProtoCode()).To(Equal(http.StatusOK))
+	})
+})

--- a/gun/phttp/http.go
+++ b/gun/phttp/http.go
@@ -48,8 +48,9 @@ type HTTPGun struct {
 var _ gun.Gun = (*HTTPGun)(nil)
 
 func (g *HTTPGun) Do(req *http.Request) (*http.Response, error) {
-	req.URL.Scheme = g.scheme
+	req.Host = req.URL.Host
 	req.URL.Host = g.target
+	req.URL.Scheme = g.scheme
 	return g.client.Do(req)
 }
 

--- a/gun/phttp/http_test.go
+++ b/gun/phttp/http_test.go
@@ -14,9 +14,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"github.com/yandex/pandora/aggregate"
+
 	"github.com/yandex/pandora/ammo"
 	"github.com/yandex/pandora/config"
+	"github.com/yandex/pandora/gun"
 )
 
 var _ = Describe("Base", func() {
@@ -43,7 +44,7 @@ var _ = Describe("Base", func() {
 		defer server.Close()
 		conf := NewDefaultHTTPGunClientConfig()
 		conf.Gun.Target = strings.TrimPrefix(server.URL, "http://")
-		results := make(chan<- *aggregate.Sample, 1)
+		results := gun.NewResults(1)
 		httpGun := NewHTTPGunClient(conf)
 		httpGun.BindResultsTo(results)
 

--- a/gun/phttp/http_test.go
+++ b/gun/phttp/http_test.go
@@ -6,9 +6,16 @@
 package phttp
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/yandex/pandora/aggregate"
+	"github.com/yandex/pandora/ammo"
 	"github.com/yandex/pandora/config"
 )
 
@@ -20,5 +27,39 @@ var _ = Describe("Base", func() {
 		}
 		err := config.DecodeAndValidate(data, &conf)
 		Expect(err).To(BeNil())
+	})
+
+	It("integration", func() {
+		const host = "example.com"
+		const path = "/smth"
+		expectedReq, err := http.NewRequest("GET", "http://"+host+path, nil)
+		expectedReq.Host = "" // Important. Ammo may have empty host.
+		Expect(err).To(BeNil())
+		var actualReq *http.Request
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			actualReq = req
+		}))
+		defer server.Close()
+		conf := NewDefaultHTTPGunClientConfig()
+		conf.Gun.Target = strings.TrimPrefix(server.URL, "http://")
+		results := make(chan<- *aggregate.Sample, 1)
+		httpGun := NewHTTPGunClient(conf)
+		httpGun.BindResultsTo(results)
+
+		am := &ammo.SimpleHTTP{}
+		am.Reset(expectedReq, "REQUEST")
+		err = httpGun.Shoot(context.Background(), am)
+		Expect(err).To(BeNil())
+
+		Expect(*actualReq).To(MatchFields(IgnoreExtras, Fields{
+			"Method": Equal("GET"),
+			"Proto":  Equal("HTTP/1.1"),
+			"Host":   Equal(host), // Not server host, but host from ammo.
+			"URL": PointTo(MatchFields(IgnoreExtras, Fields{
+				"Host": BeEmpty(), // Server request.
+				"Path": Equal(path),
+			})),
+		}))
 	})
 })

--- a/gun/phttp/testdata/ammo.jsonline
+++ b/gun/phttp/testdata/ammo.jsonline
@@ -1,25 +1,25 @@
-{"uri": "/00", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/01", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"tag": "hello", "uri": "/02", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/03", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/04", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/05", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/06", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/07", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"tag": "hello", "uri": "/08", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/09", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/10", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/11", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/12", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/13", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/14", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/15", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/16", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/17", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/18", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/19", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/20", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/21", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/22", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"uri": "/23", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
-{"tag": "hello", "uri": "/24", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Host": "localhost:3000", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/00", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/01", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"tag": "hello", "uri": "/02", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/03", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/04", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/05", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/06", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/07", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"tag": "hello", "uri": "/08", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/09", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/10", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/11", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/12", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/13", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/14", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/15", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/16", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/17", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/18", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/19", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/20", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/21", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/22", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"uri": "/23", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}
+{"tag": "hello", "uri": "/24", "method": "GET", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "User-Agent": "Pandora/0.0.1"}, "host": "localhost:3000"}

--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ import (
 )
 
 func init() {
-	// TODO move all registrations to different package,
-	// TODO: make and register NewDefaultConfig funcs.
+	// TODO(skipor): move all registrations to different package,
+	// TODO(skipor): make and register NewDefaultConfig funcs.
 
 	fs := afero.NewReadOnlyFs(afero.NewOsFs())
 
@@ -32,6 +32,7 @@ func init() {
 	register.Provider("dummy/log", ammo.NewLogProvider)
 
 	register.Gun("http", phttp.NewHTTPGunClient, phttp.NewDefaultHTTPGunClientConfig)
+	register.Gun("connect", phttp.NewConnectGun, phttp.NewDefaultConnectGunConfig)
 	register.Gun("spdy", phttp.NewSPDYGun)
 	register.Gun("log", gun.NewLog)
 


### PR DESCRIPTION
Gun for shooting HTTP CONNECT proxy target.

CONNECT made through custom `DialContext(ctx context.Context, network, addr string) (net.Conn, error)` 
I doubt if CONNECT request should acquire it's own Sample. In current implementation CONNECT time will be added to request sample anyway: HTTP gun stats it before Do, but CONNECT is initiated in it.
Anyway we can fix it later.

Also:
* fix problem with sending target Host header instead of ammo.
* remove Host header from jsonline example, because it is silently ignored anyway: Host field defines Host header, and Gun config defines target server. 
* add go1.8 to travis