### PR TITLE
Read YAML config from standard input when dash passed as config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ GOOS=linux GOARCH=amd64 go build
 ```
 
 ### Running your tests
-Run the binary with your config (see config examples at [examples](https://github.com/yandex/pandora/tree/master/cli/config)):
+Run the binary with your config (see config examples at [examples](https://github.com/yandex/pandora/tree/develop/examples)):
 
 ```bash
 # $GOBIN should be added to $PATH

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,14 +1,17 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
 	"runtime"
 	"runtime/pprof"
+	"strings"
 	"syscall"
 	"time"
 
@@ -23,6 +26,7 @@ import (
 
 const Version = "0.2.0"
 const defaultConfigFile = "load"
+const stdinConfig = "-"
 
 var configSearchDirs = []string{"./", "./config", "/etc/pandora"}
 
@@ -130,7 +134,7 @@ func Run() {
 		case nil:
 			log.Info("Pandora engine successfully finished it's work")
 		case err:
-			const awaitTimeout= 3 * time.Second
+			const awaitTimeout = 3 * time.Second
 			log.Error("Engine run failed. Awaiting started tasks.", zap.Error(err), zap.Duration("timeout", awaitTimeout))
 			cancel()
 			time.AfterFunc(awaitTimeout, func() {
@@ -163,12 +167,26 @@ func readConfig() *cliConfig {
 		if len(flag.Args()) > 1 {
 			zap.L().Fatal("Too many command line arguments", zap.Strings("args", flag.Args()))
 		}
-		v.SetConfigFile(flag.Args()[0])
-	}
-	err = v.ReadInConfig()
-	log.Info("Reading config", zap.String("file", v.ConfigFileUsed()))
-	if err != nil {
-		log.Fatal("Config read failed", zap.Error(err))
+		configFileName := flag.Args()[0]
+		if configFileName == stdinConfig {
+			log.Info("Reading YAML config from standard input")
+			v.SetConfigType("yaml")
+			configBuffer, err := ioutil.ReadAll(bufio.NewReader(os.Stdin))
+			if err != nil {
+				log.Fatal("Cannot read from standard input", zap.Error(err))
+			}
+			err = v.ReadConfig(strings.NewReader(string(configBuffer)))
+			if err != nil {
+				log.Fatal("Config parsing failed", zap.Error(err))
+			}
+		} else {
+			v.SetConfigFile(configFileName)
+			err = v.ReadInConfig()
+			log.Info("Reading config", zap.String("file", v.ConfigFileUsed()))
+			if err != nil {
+				log.Fatal("Config read failed", zap.Error(err))
+			}
+		}
 	}
 	conf := defaultConfig()
 	err = config.DecodeAndValidate(v.AllSettings(), conf)
@@ -233,4 +251,3 @@ func startMonitoring(conf monitoringConfig) (stop func()) {
 	}
 	return
 }
-


### PR DESCRIPTION
From the https://github.com/yandex/pandora/issues/59
> Add a posibility to receive config contents from stdin. Like less UNIX command.

Viper can help https://github.com/spf13/viper/tree/master#reading-config-from-ioreader

Open questions:
- How should we detect that config isn't YAML? (json, props, etc)
- How to auto-test this changes?

## Tested manually
```bash
$ ./pandora - < config.yml
$ cat config.yaml | ./pandora -
```