### PR TITLE
Fix  based on best practices from Effective Go

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -13,7 +13,7 @@ import (
 
 const TagName = "config"
 
-// Decodes conf to result. Doesn't zero fields.
+// Decode decodes conf to result. Doesn't zero fields.
 func Decode(conf interface{}, result interface{}) error {
 	decoder, err := mapstructure.NewDecoder(newDecoderConfig(result))
 	if err != nil {

--- a/core/coretest/schedule.go
+++ b/core/coretest/schedule.go
@@ -27,7 +27,7 @@ func ExpectScheduleNexts(sched core.Schedule, nexts ...time.Duration) {
 
 const drainLimit = 1000000
 
-// DrainSchedule starts schedule and takes all tokens from it.
+// DrainScheduleDuration starts schedule and takes all tokens from it.
 // Returns all tokens and finish time relative to start
 func DrainScheduleDuration(sched core.Schedule, startAt time.Time) []time.Duration {
 	nexts := DrainSchedule(sched)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?