### PR TITLE
Remove empty chapter about guns

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,6 @@ Pandora is a high-performance load generator in Go language. It has built-in HTT
    install
    tutorial
    advanced
-   guns
    custom
    performance
    architecture


### PR DESCRIPTION
Following `Next` at [tutorial page](https://yandexpandora.readthedocs.io/en/develop/tutorial.html) returns an empty chapter about guns. My suggestion is to remove it.

<img width="1108" alt="Screen Shot 2020-06-15 at 1 01 41 PM" src="https://user-images.githubusercontent.com/5383314/84644843-622df680-af08-11ea-9147-42d810340f68.png">
