### PR TITLE
Add ability to set latency and req/resp sizes in sample

### DIFF
--- a/core/aggregator/netsample/sample.go
+++ b/core/aggregator/netsample/sample.go
@@ -100,6 +100,18 @@ func (s *Sample) SetUserNet(code int) {
 	s.set(keyErrno, code)
 }
 
+func (s *Sample) SetLatency(d time.Duration) {
+	s.setDuration(keyLatencyMicro, d)
+}
+
+func (s *Sample) SetRequestBytes(b int) {
+	s.set(keyRequestBytes, b)
+}
+
+func (s *Sample) SetResponceBytes(b int) {
+	s.set(keyResponseBytes, b)
+}
+
 func (s *Sample) String() string {
 	return string(appendPhout(s, nil, true))
 }

--- a/core/aggregator/netsample/sample_test.go
+++ b/core/aggregator/netsample/sample_test.go
@@ -54,21 +54,37 @@ func TestSampleBehaviour(t *testing.T) {
 func TestCustomSets(t *testing.T) {
 	const tag = "UserDefine"
 	s := Acquire(tag)
-	s.SetUserDuration(100 * time.Millisecond)
+
+	userDuration := 100 * time.Millisecond
+	s.SetUserDuration(userDuration)
+
 	s.SetUserProto(0)
 	s.SetUserNet(110)
+
+	latency := 200 * time.Millisecond
+	s.SetLatency(latency)
+
+	reqBytes := 4
+	s.SetRequestBytes(reqBytes)
+
+	respBytes := 8
+	s.SetResponceBytes(respBytes)
+
 	expectedTimeStamp := fmt.Sprintf("%v.%3.f",
 		s.timeStamp.Unix(),
 		float32((s.timeStamp.UnixNano()/1e6)%1000))
 	expectedTimeStamp = strings.Replace(expectedTimeStamp, " ", "0", -1)
-	expected := fmt.Sprintf("%s\t%s#0\t%v\t0\t0\t0\t0\t0\t0\t0\t%v\t%v",
+	expected := fmt.Sprintf("%s\t%s#0\t%v\t0\t0\t%v\t0\t0\t%v\t%v\t%v\t%v",
 		expectedTimeStamp,
 		tag,
-		100000,
+		int(userDuration.Nanoseconds()/1000), // keyRTTMicro
+		int(latency.Nanoseconds()/1000),      // keyLatencyMicro
+		reqBytes,                             // keyRequestBytes
+		respBytes,                            // keyResponseBytes
 		110,
 		0,
 	)
-	assert.Equal(t, expected, s.String())
+	assert.Equal(t, s.String(), expected)
 }
 
 func TestGetErrno(t *testing.T) {


### PR DESCRIPTION
- [x] Code
- [x] Tests
- [ ] ???

Now sample monitoring does not support custom parameters that can be displayed by a Yandex tank, such as:
- Connect duration
- Latency time
- Receive time
- Send time
- ...

I want to be able to set some of them.