### PR TITLE
Fix leak of first instance gun closing.

### DIFF
--- a/core/engine/engine.go
+++ b/core/engine/engine.go
@@ -382,8 +382,10 @@ func (p *instancePool) startInstances(
 	}
 	started++
 	go func() {
-		defer firstInstance.Close()
-		runRes <- instanceRunResult{0, firstInstance.Run(runCtx)}
+		runRes <- instanceRunResult{0, func() error {
+			defer firstInstance.Close()
+			return firstInstance.Run(runCtx)
+		}()}
 	}()
 
 	for ; waiter.Wait(); started++ {


### PR DESCRIPTION
If gun has slow Close method, main function could exit before closing complete.
Closes #150 